### PR TITLE
main_gui: reset input path if it no longer exists

### DIFF
--- a/src/main_gui.rs
+++ b/src/main_gui.rs
@@ -202,6 +202,14 @@ fn core_options(app: &mut MyApp, _ctx: &egui::Context, ui: &mut egui::Ui) {
             });
             ui.end_row();
 
+            // Clear the selected paths if they no longer exist (SD card removed)
+            if let Some(input) = &app.input_path {
+                if !input.exists() {
+                    app.input_path = None;
+                    app.input_files = None;
+                }
+            }
+
             ui.label("Device ID");
             if let Some(file_list) = &app.input_files {
                 ui.add_enabled_ui(file_list.len() > 1, |ui| {


### PR DESCRIPTION
Reset the input path and files if the selected path no longer exists. This can happen when a SD card is removed from a PC. This ensures that the device ID and file list is up to date when a second SD is inserted.

Fixes #5.