### PR TITLE
`v1.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org).
 
+## [1.8.0] - 2026-05-01
+
+ - Fix decoding of constant length strings (Introduced in `1.7.0`)
+ - Fix temporary decoding files potentially being left on the filesystem
+
 ## [1.7.0] - 2026-04-14
 
  - Add button to open output folder in system viewer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infuse_decoder"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 
 [[bin]]

--- a/scripts/tdf_decoder.rs.jinja
+++ b/scripts/tdf_decoder.rs.jinja
@@ -41,7 +41,7 @@ fn tdf_field_read_string(cursor: &mut Cursor<&[u8]>, cursor_start: u64, num: u8,
 {
     let string_length = match num {
         0 => vla_bytes_remaining(cursor, cursor_start, size)?,
-        _ => size as usize,
+        _ => num as usize,
     };
 
     let mut buf = vec![0u8; string_length];
@@ -68,7 +68,7 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
 
     let res = match tdf_id {
 {% for tdf_id, info in definitions.items() %}
-        {{ tdf_id }} => 
+        {{ tdf_id }} =>
             Ok(format!(
                 "{{ info['rust_fmt'] }}",
 {% for conv in info['rust_convs'] %}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,12 @@ impl TdfOutput for TdfCsvWriter {
                 let heading = tdf::decoders::tdf_fields(&tdf_id).join(",");
                 writer.write_all(format!("time,{}\n", heading).as_bytes())?;
 
+                // Touch the count variable in case the decoding fails
+                *self
+                    .output_cnt
+                    .entry((remote_id, tdf_id.to_owned()))
+                    .or_default() += 0;
+
                 // Insert into hashmap and return
                 v.insert((path, writer))
             }

--- a/tdf/src/decoders.rs
+++ b/tdf/src/decoders.rs
@@ -155,7 +155,7 @@ fn tdf_field_read_string(cursor: &mut Cursor<&[u8]>, cursor_start: u64, num: u8,
 {
     let string_length = match num {
         0 => vla_bytes_remaining(cursor, cursor_start, size)?,
-        _ => size as usize,
+        _ => num as usize,
     };
 
     let mut buf = vec![0u8; string_length];
@@ -181,7 +181,7 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
     let cursor_start = cursor.position();
 
     let res = match tdf_id {
-        1 => 
+        1 =>
             Ok(format!(
                 "0x{:08x},{},{},{},0x{:08x},0x{:08x},{},{},{},0x{:02x}",
                 cursor.read_u32::<LittleEndian>()?,
@@ -195,32 +195,32 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_u16::<LittleEndian>()?,
                 cursor.read_u8()?,
             )),
-        2 => 
+        2 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_u32::<LittleEndian>()?,
                 cursor.read_i32::<LittleEndian>()?,
                 cursor.read_u8()?,
             )),
-        3 => 
+        3 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i32::<LittleEndian>()? as f64 / 1000.0,
                 cursor.read_u32::<LittleEndian>()? as f64 / 1000.0,
                 cursor.read_u16::<LittleEndian>()? as f64 / 100.0,
             )),
-        4 => 
+        4 =>
             Ok(format!(
                 "{}",
                 cursor.read_i32::<LittleEndian>()? as f64 / 1000.0,
             )),
-        5 => 
+        5 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_u8()?,
                 cursor.read_i32::<LittleEndian>()? as f64 / 1000000.0,
             )),
-        6 => 
+        6 =>
             Ok(format!(
                 "{},0x{:08x},{},{},0x{:08x},0x{:08x},{}",
                 cursor.read_u8()?,
@@ -231,7 +231,7 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_u32::<LittleEndian>()?,
                 tdf_field_read_string(cursor, cursor_start, 8, size)?,
             )),
-        7 => 
+        7 =>
             Ok(format!(
                 "0x{:08x},{},{},{},0x{:08x},0x{:04x},0x{:08x},{},{},{},0x{:02x}",
                 cursor.read_u32::<LittleEndian>()?,
@@ -246,75 +246,75 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_u16::<LittleEndian>()?,
                 cursor.read_u8()?,
             )),
-        8 => 
+        8 =>
             Ok(format!(
                 "{}",
                 cursor.read_i16::<LittleEndian>()? as f64 / 100.0,
             )),
-        10 => 
+        10 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        11 => 
+        11 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        12 => 
+        12 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        13 => 
+        13 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        14 => 
+        14 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        15 => 
+        15 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        16 => 
+        16 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        17 => 
+        17 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        18 => 
+        18 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        19 => 
+        19 =>
             Ok(format!(
                 "{},{},{},{},{}",
                 cursor.read_i32::<LittleEndian>()? as f64 / 10000000.0,
@@ -323,7 +323,7 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_i32::<LittleEndian>()? as f64 / 1000.0,
                 cursor.read_i32::<LittleEndian>()? as f64 / 1000.0,
             )),
-        20 => 
+        20 =>
             Ok(format!(
                 "{},{},{},{},{},{},{},0x{:02x},{},{},{},0x{:02x},0x{:02x},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},0x{:04x},{},{},{},{},{},{},{}",
                 cursor.read_u32::<LittleEndian>()?,
@@ -363,7 +363,7 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_i16::<LittleEndian>()? as f64 / 100.0,
                 cursor.read_u16::<LittleEndian>()? as f64 / 100.0,
             )),
-        21 => 
+        21 =>
             Ok(format!(
                 "{},{},{},{},{},{},{},{},{}",
                 cursor.read_u16::<LittleEndian>()?,
@@ -376,7 +376,7 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_u8()? as f64 / -1.0,
                 cursor.read_i8()?,
             )),
-        22 => 
+        22 =>
             Ok(format!(
                 "{},{},{},{},{},{},{},{},{}",
                 cursor.read_u8()?,
@@ -389,78 +389,78 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_u8()?,
                 cursor.read_u8()?,
             )),
-        23 => 
+        23 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_u32::<LittleEndian>()?,
                 cursor.read_u32::<LittleEndian>()?,
             )),
-        24 => 
+        24 =>
             Ok(format!(
                 "{}",
                 cursor.read_u32::<LittleEndian>()?,
             )),
-        25 => 
+        25 =>
             Ok(format!(
                 "0x{:08x},{},{}",
                 cursor.read_u32::<LittleEndian>()?,
                 cursor.read_u16::<LittleEndian>()?,
                 tdf_field_read_vla(cursor, cursor_start, size)?,
             )),
-        26 => 
+        26 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_u32::<LittleEndian>()?,
                 cursor.read_u32::<LittleEndian>()?,
             )),
-        27 => 
+        27 =>
             Ok(format!(
                 "{}",
                 cursor.read_u8()?,
             )),
-        28 => 
+        28 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_u16::<LittleEndian>()?,
                 cursor.read_u16::<LittleEndian>()?,
                 cursor.read_u8()?,
             )),
-        29 => 
+        29 =>
             Ok(format!(
                 "{},0x{:012x},{}",
                 cursor.read_u8()?,
                 cursor.read_u48::<LittleEndian>()?,
                 cursor.read_u8()?,
             )),
-        30 => 
+        30 =>
             Ok(format!(
                 "{},0x{:012x},{}",
                 cursor.read_u8()?,
                 cursor.read_u48::<LittleEndian>()?,
                 cursor.read_i8()?,
             )),
-        31 => 
+        31 =>
             Ok(format!(
                 "{},0x{:012x},{}",
                 cursor.read_u8()?,
                 cursor.read_u48::<LittleEndian>()?,
                 cursor.read_i32::<LittleEndian>()?,
             )),
-        32 => 
+        32 =>
             Ok(format!(
                 "0x{:08x},{},{}",
                 cursor.read_u32::<LittleEndian>()?,
                 cursor.read_u16::<LittleEndian>()?,
                 tdf_field_read_vla(cursor, cursor_start, size)?,
             )),
-        33 => 
+        33 =>
             Ok(format!(
                 "0x{:08x},{},{}",
                 cursor.read_u32::<LittleEndian>()?,
                 cursor.read_u16::<LittleEndian>()?,
                 tdf_field_read_vla(cursor, cursor_start, size)?,
             )),
-        34 => 
+        34 =>
             Ok(format!(
                 "{},{},{},{},{},{},{},{},{},{},{},{}",
                 cursor.read_u16::<LittleEndian>()?,
@@ -476,19 +476,19 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_u8()? as f64 / -1.0,
                 cursor.read_i8()?,
             )),
-        35 => 
+        35 =>
             Ok(format!(
                 "0x{:012x},{},{}",
                 cursor.read_u48::<BigEndian>()?,
                 cursor.read_u8()?,
                 cursor.read_i8()?,
             )),
-        36 => 
+        36 =>
             Ok(format!(
                 "{}",
                 cursor.read_f32::<LittleEndian>()?,
             )),
-        37 => 
+        37 =>
             Ok(format!(
                 "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},0x{:02x},{}",
                 cursor.read_i32::<LittleEndian>()? as f64 / 10000000.0,
@@ -516,63 +516,63 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_u8()?,
                 cursor.read_u8()?,
             )),
-        38 => 
+        38 =>
             Ok(format!(
                 "{}",
                 cursor.read_i32::<LittleEndian>()?,
             )),
-        39 => 
+        39 =>
             Ok(format!(
                 "0x{:016x},{}",
                 cursor.read_u64::<LittleEndian>()?,
                 cursor.read_i8()?,
             )),
-        40 => 
+        40 =>
             Ok(format!(
                 "{}",
                 cursor.read_i8()?,
             )),
-        41 => 
+        41 =>
             Ok(format!(
                 "{}",
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        42 => 
+        42 =>
             Ok(format!(
                 "{}",
                 cursor.read_i32::<LittleEndian>()?,
             )),
-        43 => 
+        43 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_u32::<LittleEndian>()?,
                 tdf_field_read_string(cursor, cursor_start, 0, size)?,
             )),
-        44 => 
+        44 =>
             Ok(format!(
                 "{},{},{}",
                 cursor.read_i8()?,
                 cursor.read_i16::<LittleEndian>()?,
                 tdf_field_read_vla(cursor, cursor_start, size)?,
             )),
-        45 => 
+        45 =>
             Ok(format!(
                 "{}",
                 tdf_field_read_vla(cursor, cursor_start, size)?,
             )),
-        46 => 
+        46 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_u16::<LittleEndian>()?,
                 cursor.read_u32::<LittleEndian>()?,
             )),
-        47 => 
+        47 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_u16::<LittleEndian>()?,
                 cursor.read_u32::<LittleEndian>()?,
             )),
-        48 => 
+        48 =>
             Ok(format!(
                 "0x{:012x},{},{},{},{},{},{},{},{}",
                 cursor.read_u48::<BigEndian>()?,
@@ -585,70 +585,70 @@ pub fn tdf_read_into_str(tdf_id: &u16, size: u8, cursor: &mut Cursor<&[u8]>) -> 
                 cursor.read_u16::<LittleEndian>()?,
                 cursor.read_u8()?,
             )),
-        49 => 
+        49 =>
             Ok(format!(
                 "{}",
                 cursor.read_u8()?,
             )),
-        50 => 
+        50 =>
             Ok(format!(
                 "{}",
                 cursor.read_u8()?,
             )),
-        51 => 
+        51 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_u8()?,
                 cursor.read_u8()?,
             )),
-        52 => 
+        52 =>
             Ok(format!(
                 "{}",
                 tdf_field_read_vla(cursor, cursor_start, size)?,
             )),
-        53 => 
+        53 =>
             Ok(format!(
                 "{}",
                 cursor.read_u16::<LittleEndian>()?,
             )),
-        54 => 
+        54 =>
             Ok(format!(
                 "{}",
                 cursor.read_u8()?,
             )),
-        55 => 
+        55 =>
             Ok(format!(
                 "{}",
                 cursor.read_u8()?,
             )),
-        56 => 
+        56 =>
             Ok(format!(
                 "{}",
                 cursor.read_u8()?,
             )),
-        57 => 
+        57 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_u8()?,
                 cursor.read_u32::<LittleEndian>()?,
             )),
-        58 => 
+        58 =>
             Ok(format!(
                 "{}",
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        59 => 
+        59 =>
             Ok(format!(
                 "{}",
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        60 => 
+        60 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_i16::<LittleEndian>()?,
                 cursor.read_i16::<LittleEndian>()?,
             )),
-        61 => 
+        61 =>
             Ok(format!(
                 "{},{}",
                 cursor.read_u16::<LittleEndian>()?,


### PR DESCRIPTION
 - Fix decoding of constant length strings (Introduced in `1.7.0`)
 - Fix temporary decoding files potentially being left on the filesystem